### PR TITLE
Fix regex for file-like requests in Nginx configuration

### DIFF
--- a/apps/web-client/nginx.prod.conf
+++ b/apps/web-client/nginx.prod.conf
@@ -17,7 +17,7 @@ server {
 
   # For file-like requests, serve only if the file exists.
   # Missing files should be 404 instead of index.html.
-  location ~* \.[a-z0-9]{1,8}$ {
+  location ~* "\.[a-z0-9][a-z0-9]*$" {
     try_files $uri =404;
   }
 


### PR DESCRIPTION
## Summary

Correct the regex for file-like requests to ensure proper 404 handling for missing files instead of serving index.html.
