### PR TITLE
Add health checks for web-client and api-server in production configuration

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,8 +13,10 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - web-client
-      - api-server
+      web-client:
+        condition: service_healthy
+      api-server:
+        condition: service_healthy
 
   web-client:
     build:
@@ -24,6 +26,12 @@ services:
         VITE_API_BASE_URL: ${VITE_API_BASE_URL}
     container_name: pawn-web-client-prod
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   api-server:
     build:
@@ -48,6 +56,16 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=3)\" || exit 1"
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 25s
 
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary

Introduce health checks for the web-client and api-server services to ensure they are running properly before other services depend on them.
