### PR TITLE
Update healthcheck command for web-client

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
     container_name: pawn-web-client-prod
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q --spider http://localhost/ || exit 1"]
+      test: ["CMD-SHELL", "nginx -t -q || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
## Summary

Change the healthcheck command for the web-client to use the nginx test instead of wget, improving reliability.
