### PR TITLE
Add db-bootstrap service for automatic database initialization

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -23,6 +23,7 @@ ADMIN_PASSWORD=replace_with_strong_admin_password
 ADMIN_ROLE=administrator
 
 # Bootstrap flags
-DB_INIT_ON_STARTUP=true
+# In production, db-bootstrap service handles initialization before API startup.
+DB_INIT_ON_STARTUP=false
 DB_SEED_ON_STARTUP=false
 DB_SEED_FORCE=false

--- a/apps/api-server/src/main.py
+++ b/apps/api-server/src/main.py
@@ -38,7 +38,6 @@ def health() -> JSONResponse:
     try:
         with engine.connect() as connection:
             connection.execute(text("SELECT 1"))
-            connection.execute(text("SELECT 1 FROM users LIMIT 1"))
     except SQLAlchemyError as exc:
         return JSONResponse(
             status_code=503,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,28 @@ services:
       retries: 10
       start_period: 10s
 
+  db-bootstrap:
+    build:
+      context: ./apps/api-server
+      dockerfile: Dockerfile.prod
+    container_name: pawn-db-bootstrap-prod
+    restart: "no"
+    env_file:
+      - ./.env.production
+    environment:
+      APP_ENV: ${APP_ENV}
+      DATABASE_URL: ${DATABASE_URL}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      JWT_ALGORITHM: ${JWT_ALGORITHM}
+      JWT_ACCESS_TOKEN_EXPIRE_MINUTES: ${JWT_ACCESS_TOKEN_EXPIRE_MINUTES}
+      ADMIN_USERNAME: ${ADMIN_USERNAME}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+      ADMIN_ROLE: ${ADMIN_ROLE}
+    command: ["python", "-m", "src.infrastructure.tasks.bootstrap_db"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   api-server:
     build:
       context: ./apps/api-server
@@ -50,12 +72,14 @@ services:
       ADMIN_USERNAME: ${ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
       ADMIN_ROLE: ${ADMIN_ROLE}
-      DB_INIT_ON_STARTUP: ${DB_INIT_ON_STARTUP:-true}
+      DB_INIT_ON_STARTUP: ${DB_INIT_ON_STARTUP:-false}
       DB_SEED_ON_STARTUP: ${DB_SEED_ON_STARTUP:-false}
       DB_SEED_FORCE: ${DB_SEED_FORCE:-false}
     depends_on:
       postgres:
         condition: service_healthy
+      db-bootstrap:
+        condition: service_completed_successfully
     healthcheck:
       test:
         [

--- a/docs/deployment-digitalocean.md
+++ b/docs/deployment-digitalocean.md
@@ -89,6 +89,8 @@ From repository root:
 docker compose --env-file .env.production -f docker-compose.prod.yml up --build -d
 ```
 
+Production compose includes a one-shot `db-bootstrap` service that initializes schema/admin data before the API starts. This keeps deployment automatic and avoids manual DB bootstrap commands in normal operation.
+
 Check status:
 
 ```bash
@@ -99,6 +101,12 @@ Tail logs:
 
 ```bash
 docker compose --env-file .env.production -f docker-compose.prod.yml logs -f
+```
+
+If API appears unhealthy, check bootstrap logs first:
+
+```bash
+docker compose --env-file .env.production -f docker-compose.prod.yml logs db-bootstrap
 ```
 
 ## 8) Verify Deployment


### PR DESCRIPTION
## Summary

Introduce a `db-bootstrap` service for automatic database initialization in production, ensuring the database is set up before the API starts. Disable the `DB_INIT_ON_STARTUP` flag in production to prevent redundant initialization. Refactor the health check to remove unnecessary database queries and update the DigitalOcean deployment guide to reflect these changes.
