### PR TITLE
docs(deploy): describe ADMIN_PASSWORD as a first-boot seed, not a live secret

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -17,14 +17,27 @@ DATABASE_URL=postgresql+psycopg://pawn_user:replace_with_strong_password@postgre
 VITE_API_BASE_URL=https://app.example.com/api/v1
 
 # API security
+# MUST be replaced. The API refuses to start with APP_ENV=production while this still holds
+# the development default `change_this_in_production`: it is published in the README and in
+# .env.example, so anyone could sign a token for any user. Generate one with:
+#   openssl rand -base64 48
+# Changing it later invalidates every open session, which is expected.
 JWT_SECRET_KEY=replace_with_minimum_32_char_secret
 JWT_ALGORITHM=HS256
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=60
 
-# Initial admin user
+# Initial admin user — used ONLY to create this account the first time the stack boots.
+# After that the password lives in the database and the operator changes it from the users
+# screen, so this variable goes stale by design and is not the live credential. Editing it
+# later has no effect on the stored password unless ADMIN_PASSWORD_RESET_ON_STARTUP is on.
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=replace_with_strong_admin_password
 ADMIN_ROLE=administrator
+
+# Recovery escape hatch, off by default. Turning it on overwrites the stored admin password
+# with ADMIN_PASSWORD on the next boot — which throws away whatever the operator had set, so
+# only use it when the account is locked out, and turn it back off afterwards.
+ADMIN_PASSWORD_RESET_ON_STARTUP=false
 
 # Bootstrap flags
 # db-bootstrap runs first; keep this enabled as a safe self-healing fallback.

--- a/docs/deployment-digitalocean.md
+++ b/docs/deployment-digitalocean.md
@@ -75,11 +75,18 @@ Edit `.env.production` and set secure values:
 - `DOMAIN` (for example `app.example.com`)
 - `POSTGRES_PASSWORD`
 - `DATABASE_URL`
-- `JWT_SECRET_KEY`
-- `ADMIN_PASSWORD`
+- `JWT_SECRET_KEY` — **required**: the API refuses to start in production while this holds the
+  published development default. Generate one with `openssl rand -base64 48`.
+- `ADMIN_PASSWORD` — only seeds the admin account on the very first boot
 - `VITE_API_BASE_URL` (for example `https://app.example.com/api/v1`)
 
 Important: `DATABASE_URL` credentials must match `POSTGRES_USER` and `POSTGRES_PASSWORD`.
+
+`ADMIN_PASSWORD` is not the live credential. Once the account exists, the password lives in the
+database and the operator changes it from the users screen, so this variable goes stale by
+design — editing it later changes nothing. If the admin is ever locked out, set
+`ADMIN_PASSWORD_RESET_ON_STARTUP=true` for one boot and turn it back off; be aware that this
+overwrites whatever password the operator had set.
 
 ## 7) Deploy the Stack
 
@@ -191,7 +198,9 @@ cat /opt/pawn_loan_backup.sql | docker compose --env-file .env.production -f doc
 
 ## 11) Security Recommendations
 
-- Use long random secrets for `POSTGRES_PASSWORD`, `JWT_SECRET_KEY`, and `ADMIN_PASSWORD`.
+- Use long random secrets for `POSTGRES_PASSWORD` and `JWT_SECRET_KEY`. Use a strong
+  `ADMIN_PASSWORD` too, but remember it only applies to the first boot — the password that
+  actually guards the account is the one stored in the database, changed from the users screen.
 - Keep system packages updated (`apt update && apt upgrade -y`).
 - Restrict SSH (disable password login, optionally change port).
 - Use DigitalOcean backups and snapshots.


### PR DESCRIPTION
## Summary

Follow-up to `9ba50d9`, which stopped the production startup guard from rejecting a stale
`ADMIN_PASSWORD`. The configuration files still described that variable as a live secret to
maintain, which is what led to it being treated as one.

- `.env.production.example` now says `JWT_SECRET_KEY` is the value that **must** be replaced —
  the API refuses to start in production while it holds the published default — and that
  `ADMIN_PASSWORD` only seeds the admin account on the very first boot.
- Documents `ADMIN_PASSWORD_RESET_ON_STARTUP` as a locked-out-recovery escape hatch, with the
  warning that it overwrites whatever password the operator had set.
- `docs/deployment-digitalocean.md` carries the same distinction in the setup steps and in the
  security recommendations.

## Deployment notes

Documentation only — no code, no migrations, no schema change, no data touched.

Merging this triggers the release workflow, which is what ships `9ba50d9` to the droplet: that
commit reached `main` through a direct push, so it passed Quality Checks there but never went
through a deploy. After this release, `.env.production` no longer needs `ADMIN_PASSWORD` set to
any particular value for the API to boot.

## Checklist

- [x] I tested locally — ruff and 146 tests on PostgreSQL are green on `main` as of `9ba50d9`;
      this change touches no code
- [x] I updated documentation if needed — that is the whole change
- [x] I verified no sensitive data is exposed — placeholders only
