### PR TITLE
Void, pause and settle a loan — and fix the stale-session landing

### DIFF
--- a/apps/web-client/src/modules/authentication/authState.ts
+++ b/apps/web-client/src/modules/authentication/authState.ts
@@ -81,15 +81,42 @@ const login = async (payload: LoginPayload) => {
   await fetchCurrentUser()
 }
 
-const fetchCurrentUser = async () => {
-  if (!state.accessToken) return
-  const response = await fetch(`${API_BASE_URL}/auth/me`, {
-    headers: { Authorization: `Bearer ${state.accessToken}` }
-  })
-  if (response.ok) {
-    state.currentUser = (await response.json()) as UserProfile
-  } else {
-    logout()
+/** Confirms the stored token still names a session, and loads who it belongs to.
+ *
+ * The router awaits this before it decides whether a guarded route may be entered, so two
+ * things matter beyond fetching a profile.
+ *
+ * **It must not throw.** An exception here escapes the navigation guard and the router
+ * rejects the navigation outright — the app stops on whatever was on screen, which for a
+ * cold start is nothing at all. A dropped connection is not a reason to show a blank page.
+ *
+ * **Only the server rejecting the token ends the session.** A 5xx, a timeout or an
+ * unreachable host say nothing about whether the token is valid, and signing the operator
+ * out over them would discard a good session because a proxy hiccuped. That is the same
+ * distinction `LoginView` makes between `auth.invalidCredentials` and
+ * `auth.serviceUnreachable`: a request that was never answered has made no claim.
+ */
+const fetchCurrentUser = async (): Promise<boolean> => {
+  if (!state.accessToken) return false
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/auth/me`, {
+      headers: { Authorization: `Bearer ${state.accessToken}` }
+    })
+
+    if (response.ok) {
+      state.currentUser = (await response.json()) as UserProfile
+      return true
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      logout()
+    }
+
+    return false
+  } catch {
+    // Never answered: keep the session and let the app try again on the next request.
+    return false
   }
 }
 

--- a/apps/web-client/src/router/index.ts
+++ b/apps/web-client/src/router/index.ts
@@ -71,12 +71,25 @@ const router = createRouter({
 router.beforeEach(async (to) => {
   const { isAuthenticated, state, fetchCurrentUser, hasRole } = useAuthState()
 
-  if (to.matched.some((record) => record.meta.requiresAuth) && !isAuthenticated.value) {
-    return { path: '/login', query: { redirect: to.fullPath } }
-  }
-
+  /* Verify the stored token BEFORE deciding whether the route may be entered.
+   *
+   * These two steps used to be the other way round, and the order was the whole bug: a
+   * token left in localStorage from an expired session made `isAuthenticated` true, so the
+   * guard admitted the navigation, and only then awaited `/auth/me`. That call clears the
+   * session on rejection — but the entry decision had already been made and was never
+   * revisited, so the app opened straight onto a dashboard whose every request then failed,
+   * showing a full screen of zeros. Reloading re-ran the guard, now with no token, and
+   * finally landed on the sign-in screen: the "just refresh it" that made this look flaky
+   * rather than broken.
+   *
+   * Having the token is not the same as having a session, and this is the line where the
+   * difference is settled. */
   if (isAuthenticated.value && !state.currentUser) {
     await fetchCurrentUser()
+  }
+
+  if (to.matched.some((record) => record.meta.requiresAuth) && !isAuthenticated.value) {
+    return { path: '/login', query: { redirect: to.fullPath } }
   }
 
   if (to.meta.guestOnly && isAuthenticated.value) {


### PR DESCRIPTION
Three operator escape hatches that forgive money, so all three record who, when
and why on the row itself.

Voiding marks a charge, never deletes it — the row keeps its period slot, which
stops the generator billing that month again. Refused while a live payment points
at it. Pausing is a flag, not a status: it stops new charges and penalties while
existing debt stays owed and visible, and each paused month gets a zero-amount
marker so the pause never lands as one lump on resume. Settling applies the money
oldest-first and voids the interest it cannot cover; the operator chooses whether
the pledge goes back or stays for sale.

Also fixes a session bug: opening the app on an expired token showed a dashboard
of zeros until you reloaded. The route guard decided entry before verifying the
token and never revisited that decision.

Plus one treatment for destructive row actions (they had drifted across three),
a light accent that no longer reads as a near-black smudge as a fill, and date
fields that resolve their own placeholder.

Contains a migration (20260809_0017). Verified: ruff, 210 tests on PostgreSQL,
vue-tsc, check:i18n, check:contrast, build.
