### PR TITLE
Fix loan due date calculation on disbursement day

### DIFF
--- a/apps/api-server/src/modules/finance/interest_generation.py
+++ b/apps/api-server/src/modules/finance/interest_generation.py
@@ -37,29 +37,38 @@ def accruing_loans(db: Session) -> list[Loan]:
     return list(db.scalars(select(Loan).where(Loan.status.in_(ACCRUING_STATUSES))).all())
 
 
-def _month_anchor(year: int, month: int, anchor_day: int) -> date:
+def month_anchor(year: int, month: int, anchor_day: int) -> date:
+    """The anchor day clamped into a month that may be shorter than it.
+
+    Public because the billing cycle and the statement that tells a customer when their next
+    payment falls due must agree by construction. There were two byte-identical copies of this
+    and `add_months`, one in each module — the same duplication that has bitten this codebase
+    through `formatCurrency`, the payment-type map and the period-state helper. Here it would
+    have been worse than cosmetic: the two would have been deciding *when a period is billed*
+    and *what date the customer was promised*.
+    """
     last_day = monthrange(year, month)[1]
     day = min(max(1, anchor_day), last_day)
     return date(year, month, day)
 
 
-def _add_months(base_date: date, months: int, anchor_day: int) -> date:
+def add_months(base_date: date, months: int, anchor_day: int) -> date:
     month_index = (base_date.month - 1) + months
     year = base_date.year + (month_index // 12)
     month = (month_index % 12) + 1
-    return _month_anchor(year, month, anchor_day)
+    return month_anchor(year, month, anchor_day)
 
 
 def _iter_due_periods(as_of_date: date, disbursement_date: date) -> list[tuple[date, date]]:
     anchor_day = disbursement_date.day
     period_start = disbursement_date
-    period_end = _add_months(disbursement_date, 1, anchor_day)
+    period_end = add_months(disbursement_date, 1, anchor_day)
 
     periods: list[tuple[date, date]] = []
     while period_end <= as_of_date:
         periods.append((period_start, period_end))
         period_start = period_end
-        period_end = _add_months(period_end, 1, anchor_day)
+        period_end = add_months(period_end, 1, anchor_day)
 
     return periods
 

--- a/apps/api-server/src/modules/payments/router.py
+++ b/apps/api-server/src/modules/payments/router.py
@@ -1,4 +1,3 @@
-from calendar import monthrange
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -9,6 +8,7 @@ from src.domain.enums.loan import LoanStatus
 from src.infrastructure.persistence.models import InterestCharge, Loan, Payment, PaymentEvent, User
 from src.infrastructure.utils.datetime_utils import get_local_date, get_local_datetime
 from src.modules.finance.allocation import AllocationTarget, allocate_oldest_first
+from src.modules.finance.interest_generation import add_months, month_anchor
 from src.modules.finance.locks import lock_customer_loans, lock_loans
 from src.modules.finance.loan_status import describe_transitions, refresh_overdue_loan_statuses
 from src.modules.finance.interest_balance import (
@@ -49,27 +49,27 @@ from src.shared.utils.audit import write_audit
 router = APIRouter(prefix="/payments", tags=["payments"])
 
 
-def _month_anchor(year: int, month: int, anchor_day: int) -> date:
-    last_day = monthrange(year, month)[1]
-    day = min(max(1, anchor_day), last_day)
-    return date(year, month, day)
-
-
-def _add_months(base_date: date, months: int, anchor_day: int) -> date:
-    month_index = (base_date.month - 1) + months
-    year = base_date.year + (month_index // 12)
-    month = (month_index % 12) + 1
-    return _month_anchor(year, month, anchor_day)
-
 
 def _next_interest_generation_date(as_of_date: date, disbursement_date: date) -> date:
+    """The end of the billing period the loan is currently inside.
+
+    A loan disbursed on the 19th has its first period run 19th -> 19th of the next month, so
+    on the day it is signed nothing is due yet. The anchor for the current month is the
+    disbursement date itself, and returning it made a statement printed the same afternoon
+    read "próximo vencimiento: 19/08/2026" — the day it was handed over. The guard below is
+    what keeps the answer strictly in the future of the disbursement.
+    """
     anchor_day = disbursement_date.day
-    current_anchor = _month_anchor(as_of_date.year, as_of_date.month, anchor_day)
+    current_anchor = month_anchor(as_of_date.year, as_of_date.month, anchor_day)
+
+    # Never the disbursement day or earlier: no period has ended yet.
+    if current_anchor <= disbursement_date:
+        return add_months(disbursement_date, 1, anchor_day)
 
     if as_of_date <= current_anchor:
         return current_anchor
 
-    return _add_months(current_anchor, 1, anchor_day)
+    return add_months(current_anchor, 1, anchor_day)
 
 
 def _pending_interest_items_for_customer(db: Session, customer_id: int, today: date) -> list[InterestPendingItem]:

--- a/apps/api-server/tests/test_next_due_date.py
+++ b/apps/api-server/tests/test_next_due_date.py
@@ -1,0 +1,56 @@
+"""The next due date is never the day the loan was signed.
+
+A statement printed the same afternoon a loan was disbursed read "próximo vencimiento" as
+that very day. The first billing period runs from the disbursement to the same day of the
+next month, so on day zero nothing has fallen due yet.
+"""
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.infrastructure.persistence.models import Loan
+from src.modules.payments.router import _next_interest_generation_date as next_due
+
+
+def test_the_day_it_is_signed_points_at_next_month() -> None:
+    signed = date(2026, 8, 19)
+    assert next_due(signed, signed) == date(2026, 9, 19)
+
+
+def test_the_day_after_still_points_at_the_first_period_end() -> None:
+    signed = date(2026, 8, 19)
+    assert next_due(date(2026, 8, 20), signed) == date(2026, 9, 19)
+
+
+def test_the_period_end_itself_is_the_answer_that_day() -> None:
+    """On the day a period closes, that day *is* the due date — this is the case the old
+    `<=` was written for, and it has to keep working."""
+    signed = date(2026, 8, 19)
+    assert next_due(date(2026, 9, 19), signed) == date(2026, 9, 19)
+    assert next_due(date(2026, 9, 20), signed) == date(2026, 10, 19)
+
+
+def test_a_month_end_anchor_lands_on_the_shortest_month() -> None:
+    """A loan signed on the 31st has no 31st to fall on in February."""
+    assert next_due(date(2026, 1, 31), date(2026, 1, 31)) == date(2026, 2, 28)
+    assert next_due(date(2026, 8, 31), date(2026, 8, 31)) == date(2026, 9, 30)
+
+
+def test_a_freshly_created_loan_prints_a_future_due_date(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str], create_loan
+) -> None:
+    """End to end, through the endpoint the printed statement actually reads."""
+    loan = create_loan(principal=1000.0)
+    row = db_session.get(Loan, loan["id"])
+
+    response = client.get(
+        f"/api/v1/payments/customers/{row.customer_id}/principal-context", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+
+    item = next(i for i in response.json()["items"] if i["loan_id"] == loan["id"])
+    assert item["next_due_date"] > item["disbursement_date"], (
+        "a loan cannot fall due on the day it was handed over"
+    )


### PR DESCRIPTION
## Summary

Adjust the loan due date calculation to ensure that a loan does not fall due on the day it is disbursed. Consolidate duplicate month arithmetic functions to maintain consistency in billing periods and customer statements. Add tests to verify the new behavior and ensure accuracy in various scenarios.

## Checklist

- [x] I tested locally
- [ ] I updated documentation if needed
- [ ] I verified no sensitive data is exposed

